### PR TITLE
Add server commands to defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,25 @@ python run.py
 
 Then, you can chat with the virtual seeker.
 
+## Project Initialization
+
+The repository offers a small helper to generate default configuration files.
+Run the following snippet to create a `settings.yaml` and `.env` in the target
+directory:
+
+```python
+from pathlib import Path
+from config import initialize_project_at
+
+initialize_project_at(Path("."))
+```
+
+The generated `settings.yaml` contains the model service settings, the server
+startup scripts for the complaint, counselor and emotion modules as well as
+pointers to the initialization dialogue. Environment
+variables are written to `.env` with the `ANNA_ENGINE_` prefix for easy
+override.
+
 ## Work Progress
 
 To make it easier for readers to learn how to use it, we have added the flowchart below:

--- a/backbone.py
+++ b/backbone.py
@@ -1,16 +1,16 @@
-# model_name = "glm-4-flash"
-# api_key = "df3e749b4f2e41489e20f49657c6140e.E3y0n40tt73vNRUL"
-# base_url = "https://open.bigmodel.cn/api/paas/v4"
-# model_name = "glm-4-plus"
-# api_key = "df3e749b4f2e41489e20f49657c6140e.E3y0n40tt73vNRUL"
-# base_url = "https://open.bigmodel.cn/api/paas/v4"
+"""Load base OpenAI configuration from environment."""
 
-# model_name = "openai/gpt-4o"
-# api_key = "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"
-# base_url = "https://openrouter.ai/api/v1"
+from openai import OpenAI
+
+from config import AnnaEngineConfig
+
+_cfg = AnnaEngineConfig.load()
+
+model_name: str = _cfg.model_name
+api_key: str = _cfg.api_key
+base_url: str = _cfg.base_url
 
 
-model_name = "counselor"
-api_key = "counselor"
-base_url = "http://localhost:8002/v1"
-
+def get_openai_client(api_key_override: str | None = None, base_url_override: str | None = None) -> OpenAI:
+    """Create an OpenAI client using configuration values."""
+    return OpenAI(api_key=api_key_override or api_key, base_url=base_url_override or base_url)

--- a/complaint_chain.py
+++ b/complaint_chain.py
@@ -1,68 +1,52 @@
-from openai import OpenAI
-import json
+from backbone import get_openai_client
 from event_trigger import event_trigger
+import json
+
 
 tools = [
     {
         "type": "function",
         "function": {
-            'name': 'generate_complaint_chain',
-            'description': '根据角色信息和近期遭遇的事件，生成一个患者的主诉请求认知变化链',
-            'parameters': {
+            "name": "generate_complaint_chain",
+            "description": "根据角色信息和近期遭遇的事件，生成一个患者的主诉请求认知变化链",
+            "parameters": {
                 "type": "object",
                 "properties": {
                     "chain": {
                         "type": "array",
                         "items": {
                             "type": "object",
-                            "properties": {
-                                "stage": {
-                                    "type": "integer"
-                                },
-                                "content": {
-                                    "type": "string"
-                                }
-                            },
+                            "properties": {"stage": {"type": "integer"}, "content": {"type": "string"}},
                             "additionalProperties": False,
-                            "required": [
-                                "stage",
-                                "content"
-                            ]
+                            "required": ["stage", "content"],
                         },
                         "minItems": 3,
-                        "maxItems": 7
-                        }
+                        "maxItems": 7,
+                    }
                 },
-                "required": ["chain"]
+                "required": ["chain"],
             },
-        }
+        },
     }
 ]
 
 model_name = "complaint"
 
-# 根据profile和event生成主诉启发链
+
 def gen_complaint_chain(profile):
-    # 提取患者信息
     patient_info = f"### 患者信息\n年龄：{profile['age']}\n性别：{profile['gender']}\n职业：{profile['occupation']}\n婚姻状况：{profile['martial_status']}\n症状：{profile['symptoms']}"
-
     event = event_trigger(profile)
-
-    client = OpenAI(
-        api_key="complaint_chain",
-        base_url="http://0.0.0.0:8001/v1/"
-    )
-
+    client = get_openai_client()
     response = client.chat.completions.create(
         model=model_name,
         messages=[
-            {"role": "user", "content": f"### 任务\n根据患者情况及近期遭遇事件生成患者的主诉认知变化链。请注意，事件可能与患者信息冲突，如果发生这种情况，以患者的信息为准。\n{patient_info}\n### 近期遭遇事件\n{event}"}
+            {
+                "role": "user",
+                "content": f"### 任务\n根据患者情况及近期遭遇事件生成患者的主诉认知变化链。请注意，事件可能与患者信息冲突，如果发生这种情况，以患者的信息为准。\n{patient_info}\n### 近期遭遇事件\n{event}",
+            }
         ],
         tools=tools,
-        tool_choice={"type": "function", "function": {"name": "generate_complaint_chain"}}
+        tool_choice={"type": "function", "function": {"name": "generate_complaint_chain"}},
     )
-
     chain = json.loads(response.choices[0].message.tool_calls[0].function.arguments)["chain"]
-
     return chain
-

--- a/complaint_elicitor.py
+++ b/complaint_elicitor.py
@@ -1,5 +1,4 @@
-from openai import OpenAI
-from backbone import api_key, model_name, base_url
+from backbone import get_openai_client, model_name
 import json
 
 tools = [
@@ -29,10 +28,7 @@ def transform_chain(chain):
     return transformed_chain
 
 def switch_complaint(chain, index, conversation):
-    client = OpenAI(
-        api_key=api_key,
-        base_url=base_url
-    )
+    client = get_openai_client()
 
     try:
         transformed_chain = transform_chain(chain)

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,0 +1,11 @@
+"""Configuration package."""
+
+from .models.anna_engine_config import AnnaEngineConfig
+from .initialize import initialize_project_at
+from .defaults import anna_engine_defaults
+
+__all__ = [
+    "AnnaEngineConfig",
+    "initialize_project_at",
+    "anna_engine_defaults",
+]

--- a/config/defaults.py
+++ b/config/defaults.py
@@ -1,0 +1,14 @@
+from dataclasses import dataclass
+
+@dataclass
+class AnnaEngineDefaults:
+    """Default engine configuration values."""
+
+    model_name: str = "counselor"
+    api_key: str = "counselor"
+    base_url: str = "http://localhost:8002/v1"
+    complaint_server: str = "bash complaint.sh"
+    counselor_server: str = "bash counselor.sh"
+    emotion_server: str = "bash emotion.sh"
+
+anna_engine_defaults = AnnaEngineDefaults()

--- a/config/environment_reader.py
+++ b/config/environment_reader.py
@@ -1,0 +1,155 @@
+# Copyright (c) 2024 Microsoft Corporation.
+# Licensed under the MIT License
+
+"""A configuration reader utility class."""
+
+from collections.abc import Callable
+from contextlib import contextmanager
+from enum import Enum
+from typing import Any, TypeVar
+
+from environs import Env
+
+T = TypeVar("T")
+
+KeyValue = str | Enum
+EnvKeySet = str | list[str]
+
+
+def read_key(value: KeyValue) -> str:
+    """Read a key value."""
+    if not isinstance(value, str):
+        return value.value.lower()
+    return value.lower()
+
+
+class EnvironmentReader:
+    """A configuration reader utility class."""
+
+    _env: Env
+    _config_stack: list[dict]
+
+    def __init__(self, env: Env):
+        self._env = env
+        self._config_stack = []
+
+    @property
+    def env(self):
+        """Get the environment object."""
+        return self._env
+
+    def _read_env(
+        self, env_key: str | list[str], default_value: T, read: Callable[[str, T], T]
+    ) -> T | None:
+        if isinstance(env_key, str):
+            env_key = [env_key]
+
+        for k in env_key:
+            result = read(k.upper(), default_value)
+            if result is not default_value:
+                return result
+
+        return default_value
+
+    def envvar_prefix(self, prefix: KeyValue):
+        """Set the environment variable prefix."""
+        prefix = read_key(prefix)
+        prefix = f"{prefix}_".upper()
+        return self._env.prefixed(prefix)
+
+    def use(self, value: Any | None):
+        """Create a context manager to push the value into the config_stack."""
+
+        @contextmanager
+        def config_context():
+            self._config_stack.append(value or {})
+            try:
+                yield
+            finally:
+                self._config_stack.pop()
+
+        return config_context()
+
+    @property
+    def section(self) -> dict:
+        """Get the current section."""
+        return self._config_stack[-1] if self._config_stack else {}
+
+    def str(
+        self,
+        key: KeyValue,
+        env_key: EnvKeySet | None = None,
+        default_value: str | None = None,
+    ) -> str | None:
+        """Read a configuration value."""
+        key = read_key(key)
+        if self.section and key in self.section:
+            return self.section[key]
+
+        return self._read_env(
+            env_key or key, default_value, (lambda k, dv: self._env(k, dv))
+        )
+
+    def int(
+        self,
+        key: KeyValue,
+        env_key: EnvKeySet | None = None,
+        default_value: int | None = None,
+    ) -> int | None:
+        """Read an integer configuration value."""
+        key = read_key(key)
+        if self.section and key in self.section:
+            return int(self.section[key])
+        return self._read_env(
+            env_key or key, default_value, lambda k, dv: self._env.int(k, dv)
+        )
+
+    def bool(
+        self,
+        key: KeyValue,
+        env_key: EnvKeySet | None = None,
+        default_value: bool | None = None,
+    ) -> bool | None:
+        """Read an integer configuration value."""
+        key = read_key(key)
+        if self.section and key in self.section:
+            return bool(self.section[key])
+
+        return self._read_env(
+            env_key or key, default_value, lambda k, dv: self._env.bool(k, dv)
+        )
+
+    def float(
+        self,
+        key: KeyValue,
+        env_key: EnvKeySet | None = None,
+        default_value: float | None = None,
+    ) -> float | None:
+        """Read a float configuration value."""
+        key = read_key(key)
+        if self.section and key in self.section:
+            return float(self.section[key])
+        return self._read_env(
+            env_key or key, default_value, lambda k, dv: self._env.float(k, dv)
+        )
+
+    def list(
+        self,
+        key: KeyValue,
+        env_key: EnvKeySet | None = None,
+        default_value: list | None = None,
+    ) -> list | None:
+        """Parse an list configuration value."""
+        key = read_key(key)
+        result = None
+        if self.section and key in self.section:
+            result = self.section[key]
+            if isinstance(result, list):
+                return result
+
+        if result is None:
+            result = self.str(key, env_key)
+        if result is not None:
+            result = [s.strip() for s in result.split(",")]
+            return [s for s in result if s]
+        return default_value

--- a/config/init_content.py
+++ b/config/init_content.py
@@ -1,0 +1,29 @@
+"""Default initialization content."""
+
+from .defaults import anna_engine_defaults
+
+INIT_YAML = f"""\
+model_service:
+  model_name: {anna_engine_defaults.model_name}
+  api_key: {anna_engine_defaults.api_key}
+  base_url: {anna_engine_defaults.base_url}
+servers:
+  complaint: {anna_engine_defaults.complaint_server}
+  counselor: {anna_engine_defaults.counselor_server}
+  emotion: {anna_engine_defaults.emotion_server}
+init_dialogue: AnnaAgent/run.py
+portrait: portrait
+report: report
+previous_conversations: previous_conversations
+"""
+
+INIT_DOTENV = f"""\
+ANNA_ENGINE_MODEL_NAME={anna_engine_defaults.model_name}
+ANNA_ENGINE_API_KEY={anna_engine_defaults.api_key}
+ANNA_ENGINE_BASE_URL={anna_engine_defaults.base_url}
+ANNA_ENGINE_COMPLAINT_SERVER={anna_engine_defaults.complaint_server}
+ANNA_ENGINE_COUNSELOR_SERVER={anna_engine_defaults.counselor_server}
+ANNA_ENGINE_EMOTION_SERVER={anna_engine_defaults.emotion_server}
+GLOBAL_RETRIES=3
+SCHEDULE_PARAM=default
+"""

--- a/config/initialize.py
+++ b/config/initialize.py
@@ -1,0 +1,25 @@
+import logging
+from pathlib import Path
+
+from .init_content import INIT_DOTENV, INIT_YAML
+
+logger = logging.getLogger(__name__)
+
+
+def initialize_project_at(path: Path, force: bool = False) -> None:
+    """Create default settings.yaml and .env at the given path."""
+    logger.info("Initializing project at %s", path)
+    root = Path(path)
+    root.mkdir(parents=True, exist_ok=True)
+
+    settings_yaml = root / "settings.yaml"
+    if settings_yaml.exists() and not force:
+        raise ValueError(f"Project already initialized at {root}")
+
+    with settings_yaml.open("w", encoding="utf-8") as file:
+        file.write(INIT_YAML)
+
+    dotenv = root / ".env"
+    if not dotenv.exists() or force:
+        with dotenv.open("w", encoding="utf-8") as file:
+            file.write(INIT_DOTENV)

--- a/config/models/anna_engine_config.py
+++ b/config/models/anna_engine_config.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+from environs import Env
+from pydantic import BaseModel, Field
+
+from ..defaults import anna_engine_defaults
+from ..environment_reader import EnvironmentReader
+
+
+class AnnaEngineConfig(BaseModel):
+    """Minimal configuration loaded from environment."""
+
+    model_name: str = Field(default=anna_engine_defaults.model_name)
+    api_key: str = Field(default=anna_engine_defaults.api_key)
+    base_url: str = Field(default=anna_engine_defaults.base_url)
+    complaint_server: str = Field(default=anna_engine_defaults.complaint_server)
+    counselor_server: str = Field(default=anna_engine_defaults.counselor_server)
+    emotion_server: str = Field(default=anna_engine_defaults.emotion_server)
+
+    @classmethod
+    def load(cls, root_dir: str | Path | None = None) -> "AnnaEngineConfig":
+        env = Env()
+        env_path = Path(root_dir) / ".env" if root_dir else Path(".env")
+        if env_path.exists():
+            env.read_env(env_path)
+        else:
+            env.read_env()
+        reader = EnvironmentReader(env)
+        pref = reader.envvar_prefix("ANNA_ENGINE")
+        values = {
+            "model_name": pref("MODEL_NAME", anna_engine_defaults.model_name),
+            "api_key": pref("API_KEY", anna_engine_defaults.api_key),
+            "base_url": pref("BASE_URL", anna_engine_defaults.base_url),
+            "complaint_server": pref(
+                "COMPLAINT_SERVER", anna_engine_defaults.complaint_server
+            ),
+            "counselor_server": pref(
+                "COUNSELOR_SERVER", anna_engine_defaults.counselor_server
+            ),
+            "emotion_server": pref(
+                "EMOTION_SERVER", anna_engine_defaults.emotion_server
+            ),
+        }
+        return cls(**values)

--- a/counselor.py
+++ b/counselor.py
@@ -1,14 +1,10 @@
-from openai import OpenAI
+from backbone import get_openai_client, model_name
+
 
 def counsel(messages):
-    client = OpenAI(
-        api_key="counselor",
-        base_url="http://0.0.0.0:8002/v1"
-    )
-
+    client = get_openai_client()
     response = client.chat.completions.create(
         messages=messages,
-        model="counselor"
+        model=model_name,
     )
-
     return response.choices[0].message.content

--- a/emotion_modulator.py
+++ b/emotion_modulator.py
@@ -1,70 +1,84 @@
-from openai import OpenAI
 from random import randint
 from emotion_pertuber import perturb_state
+from backbone import get_openai_client
 import json
+
 
 tools = [
     {
         "type": "function",
         "function": {
-            'name': 'emotion_inference',
-            'description': '根据profile和对话记录，推理下一句情绪',
-            'parameters': {
+            "name": "emotion_inference",
+            "description": "根据profile和对话记录，推理下一句情绪",
+            "parameters": {
                 "type": "object",
                 "properties": {
                     "emotion": {
                         "type": "string",
                         "enum": [
-                            "admiration", "amusement", "anger", "annoyance", "approval", "caring",
-                            "confusion", "curiosity", "desire", "disappointment", "disapproval",
-                            "disgust", "embarrassment", "excitement", "fear", "gratitude", "grief",
-                            "joy", "love", "nervousness", "optimism", "pride", "realization",
-                            "relief", "remorse", "sadness", "surprise", "neutral"
+                            "admiration",
+                            "amusement",
+                            "anger",
+                            "annoyance",
+                            "approval",
+                            "caring",
+                            "confusion",
+                            "curiosity",
+                            "desire",
+                            "disappointment",
+                            "disapproval",
+                            "disgust",
+                            "embarrassment",
+                            "excitement",
+                            "fear",
+                            "gratitude",
+                            "grief",
+                            "joy",
+                            "love",
+                            "nervousness",
+                            "optimism",
+                            "pride",
+                            "realization",
+                            "relief",
+                            "remorse",
+                            "sadness",
+                            "surprise",
+                            "neutral",
                         ],
-                        "description": "推理出的情绪类别，必须是GoEmotions定义的27种情绪之一。"
+                        "description": "推理出的情绪类别，必须是GoEmotions定义的27种情绪之一。",
                     }
                 },
-                "required": ["emotion"]
+                "required": ["emotion"],
             },
-        }
+        },
     }
 ]
 
 model_name = "emotion"
 
-# 根据profile和dialogue推测emotion
+
 def emotion_inferencer(profile, conversation):
-    client = OpenAI(
-        api_key="emotion_inferencer",
-        base_url="http://0.0.0.0:8000/v1/",
-    )
-
-    # 提取患者信息
+    client = get_openai_client()
     patient_info = f"### 患者信息\n年龄：{profile['age']}\n性别：{profile['gender']}\n职业：{profile['occupation']}\n婚姻状况：{profile['martial_status']}\n症状：{profile['symptoms']}"
-    
-    # 提取对话记录
     dialogue_history = "\n".join([f"{conv['role']}: {conv['content']}" for conv in conversation])
-
     response = client.chat.completions.create(
         model=model_name,
         messages=[
-            {"role": "user", "content": f"### 任务\n根据患者情况及咨访对话历史记录推测患者下一句话最可能的情绪。\n{patient_info}\n### 对话记录\n{dialogue_history}"}
+            {
+                "role": "user",
+                "content": f"### 任务\n根据患者情况及咨访对话历史记录推测患者下一句话最可能的情绪。\n{patient_info}\n### 对话记录\n{dialogue_history}",
+            }
         ],
-        # functions=[tools[0]["function"]],
-        # function_call={"name": "emotion_inference"}
         tools=tools,
-        tool_choice={"type": "function", "function": {"name": "emotion_inference"}}
+        tool_choice={"type": "function", "function": {"name": "emotion_inference"}},
     )
-    # print(response)
-
     emotion = json.loads(response.choices[0].message.tool_calls[0].function.arguments)["emotion"]
-
     return emotion
 
+
 def emotion_modulation(profile, conversation):
-    indicator = randint(0,100)
-    emotion = emotion_inferencer(profile,conversation)
-    # print(emotion)
+    indicator = randint(0, 100)
+    emotion = emotion_inferencer(profile, conversation)
     if indicator > 90:
         return perturb_state(emotion)
     else:

--- a/event_trigger.py
+++ b/event_trigger.py
@@ -1,72 +1,64 @@
 import pandas as pd
 from random import choice
-from openai import OpenAI
-from backbone import model_name, api_key, base_url
+from backbone import get_openai_client, model_name
 import json
 
-events = pd.read_csv('datasets/cbt-triggering-events.csv',header=0)
-teen_events = ["在一次重要的考试中表现不佳，比如期末考试、升学考试（如中考或高考），导致自信心受挫。",
-               "在学校里被同龄人孤立、嘲笑或遭受言语/身体上的霸凌，感到孤独无助。",
-               "父母关系破裂并最终离婚，需要适应新的家庭环境，感到不安或缺乏安全感。",
-               "陪伴多年的宠物突然生病或意外去世，第一次直面死亡的悲伤。",
-               "因为家庭原因搬到了一个陌生的城市或学校，需要重新适应新环境和结交朋友。",
-               "进入青春期后，身体发生明显变化（如长高、变声、月经初潮等），心理上也开始对自我形象产生困惑。",
-               "参加一场期待已久的竞赛（如体育比赛、演讲比赛、艺术表演）但未能取得好成绩，感到失落。",
-               "与最亲密的朋友发生争执甚至决裂，短时间内难以修复关系，陷入情绪低谷。",
-               "家里的经济状况出现问题（如父母失业或生意失败），影响到日常生活，比如不能买喜欢的东西或参与课外活动。",
-               "偶然间发现自己特别喜欢某件事情（如画画、编程、音乐、运动），并投入大量时间去练习，逐渐找到自信和成就感。"]
+
+events = pd.read_csv('datasets/cbt-triggering-events.csv', header=0)
+teen_events = [
+    "在一次重要的考试中表现不佳，比如期末考试、升学考试（如中考或高考），导致自信心受挫。",
+    "在学校里被同龄人孤立、嘲笑或遭受言语/身体上的霸凌，感到孤独无助。",
+    "父母关系破裂并最终离婚，需要适应新的家庭环境，感到不安或缺乏安全感。",
+    "陪伴多年的宠物突然生病或意外去世，第一次直面死亡的悲伤。",
+    "因为家庭原因搬到了一个陌生的城市或学校，需要重新适应新环境和结交朋友。",
+    "进入青春期后，身体发生明显变化（如长高、变声、月经初潮等），心理上也开始对自我形象产生困惑。",
+    "参加一场期待已久的竞赛（如体育比赛、演讲比赛、艺术表演）但未能取得好成绩，感到失落。",
+    "与最亲密的朋友发生争执甚至决裂，短时间内难以修复关系，陷入情绪低谷。",
+    "家里的经济状况出现问题（如父母失业或生意失败），影响到日常生活，比如不能买喜欢的东西或参与课外活动。",
+    "偶然间发现自己特别喜欢某件事情（如画画、编程、音乐、运动），并投入大量时间去练习，逐渐找到自信和成就感。",
+]
 
 tools = [
     {
         "type": "function",
         "function": {
-            'name': 'situationalising_events',
-            'description': '根据角色信息和事件，设置一个角色所处的情境。',
-            'parameters': {
+            "name": "situationalising_events",
+            "description": "根据角色信息和事件，设置一个角色所处的情境。",
+            "parameters": {
                 "type": "object",
-                "properties": {
-                    "situation": {
-                        "type": "string"
-                    }
-                },
-                "required": ["situation"]
+                "properties": {"situation": {"type": "string"}},
+                "required": ["situation"],
             },
-        }
+        },
     }
 ]
+
 
 def event_trigger(profile):
     age = int(profile['age'])
     if age < 18:
-        event = choice(teen_events)
-    elif age >= 65:
-        event = events[events['Age'] >= 60].sample(1)['Triggering_Event'].values[0]
-    else:
-        event = events[(events['Age'] >= age-5) & (events['Age'] <= age+5)].sample(1)['Triggering_Event'].values[0]
-    return event
+        return choice(teen_events)
+    if age >= 65:
+        return events[events['Age'] >= 60].sample(1)['Triggering_Event'].values[0]
+    return events[(events['Age'] >= age - 5) & (events['Age'] <= age + 5)].sample(1)[
+        'Triggering_Event'
+    ].values[0]
+
 
 def situationalising_events(profile):
-    client = OpenAI(
-        api_key=api_key,
-        base_url=base_url
-    )
-
-    # 提取患者信息
+    client = get_openai_client()
     patient_info = f"### 患者信息\n年龄：{profile['age']}\n性别：{profile['gender']}"
-
     event = event_trigger(profile)
-
     response = client.chat.completions.create(
         model=model_name,
         messages=[
-            {"role": "user", "content": f"### 任务\n根据患者情况及事件描绘一个患者所处的情境，以第二人称描述。请注意，情境中不要包含患者的个人信息(年龄、性别等)。\n{patient_info}\n### 事件\n{event}"}
+            {
+                "role": "user",
+                "content": f"### 任务\n根据患者情况及事件描绘一个患者所处的情境，以第二人称描述。请注意，情境中不要包含患者的个人信息(年龄、性别等)。\n{patient_info}\n### 事件\n{event}",
+            }
         ],
         tools=tools,
-        tool_choice={"type": "function", "function": {"name": "situationalising_events"}}
+        tool_choice={"type": "function", "function": {"name": "situationalising_events"}},
     )
-
     situation = json.loads(response.choices[0].message.tool_calls[0].function.arguments)["situation"]
-
     return situation
-
-

--- a/fill_scales.py
+++ b/fill_scales.py
@@ -1,6 +1,5 @@
-from openai import OpenAI
 import json
-from backbone import api_key, model_name, base_url
+from backbone import get_openai_client, model_name
 
 tools = [
     {
@@ -76,10 +75,7 @@ def fill_scales_previous(profile, report):
     """
     结构化信息转换成非结构化文本数据，免去模型对语义解析的理解错误
     """
-    client = OpenAI(
-        api_key=api_key,
-        base_url=base_url
-    )
+    client = get_openai_client()
 
     # Step 0：原始数据
   
@@ -270,10 +266,7 @@ def fill_scales_previous(profile, report):
 
 # 根据prompt填写量表
 def fill_scales(prompt):
-    client = OpenAI(
-        api_key=api_key,
-        base_url=base_url
-    )
+    client = get_openai_client()
     print(prompt)
     # 填写BDI量表
     task_prompt1 = (

--- a/ms_patient.py
+++ b/ms_patient.py
@@ -1,5 +1,4 @@
-from openai import OpenAI
-from backbone import api_key, model_name, base_url
+from backbone import get_openai_client, model_name
 from fill_scales import fill_scales, fill_scales_previous
 from event_trigger import event_trigger, situationalising_events
 from emotion_modulator import emotion_modulation
@@ -60,10 +59,7 @@ class MsPatient:
         # 选取对话样例
         self.system = prompt_template.format(**self.configuration)
         self.chain_index = 1
-        self.client = OpenAI(
-            api_key=api_key,
-            base_url=base_url
-        )
+        self.client = get_openai_client()
 
     def chat(self, message):
         # 更新消息列表

--- a/querier.py
+++ b/querier.py
@@ -1,6 +1,5 @@
-from openai import OpenAI
 import json
-from backbone import api_key, model_name, base_url
+from backbone import get_openai_client, model_name
 
 tools = [
     {
@@ -38,10 +37,7 @@ tools = [
 ]
 
 def is_need(utterance):
-    client = OpenAI(
-        api_key=api_key,
-        base_url=base_url
-    )
+    client = get_openai_client()
     messages = [
         {
             "role": "user",
@@ -68,10 +64,7 @@ def is_need(utterance):
 
 def query(utterance, conversations, scales):
     # 根据utterance从conversations和scales中检索必要的信息
-    client = OpenAI(
-        api_key=api_key,
-        base_url=base_url
-    )
+    client = get_openai_client()
     response = client.chat.completions.create(
         model=model_name,
         messages=[

--- a/run.py
+++ b/run.py
@@ -1,5 +1,4 @@
 from ms_patient import MsPatient
-import json
 
 if __name__ == "__main__":
     # 模拟患者信息 (非真实数据)

--- a/short_term_memory.py
+++ b/short_term_memory.py
@@ -1,6 +1,5 @@
-from openai import OpenAI
 import json
-from backbone import api_key, model_name, base_url
+from backbone import get_openai_client, model_name
 
 tools = [
     {
@@ -41,10 +40,7 @@ tools = [
 ]
 
 def analyzing_changes(scales):
-    client = OpenAI(
-        api_key=api_key,
-        base_url=base_url
-    )
+    client = get_openai_client()
     # 导入量表及问题
     bdi_scale = json.load(open("./scales/bdi.json", "r"))
     ghq_scale = json.load(open("./scales/ghq-28.json", "r"))
@@ -206,10 +202,7 @@ def analyzing_changes(scales):
     return bdi_changes, ghq_changes, sass_changes
 
 def summarize_scale_changes(scales):
-    client = OpenAI(
-        api_key=api_key,
-        base_url=base_url
-    )
+    client = get_openai_client()
     # 获取量表变化
     bdi_changes, ghq_changes, sass_changes = analyzing_changes(scales)
     messages = [

--- a/style_analyzer.py
+++ b/style_analyzer.py
@@ -1,5 +1,4 @@
-from openai import OpenAI
-from backbone import api_key, model_name, base_url
+from backbone import get_openai_client, model_name
 import json
 
 tools = [
@@ -28,10 +27,7 @@ tools = [
 
 
 def analyze_style(profile, conversations):
-    client = OpenAI(
-        api_key=api_key,
-        base_url=base_url
-    )
+    client = get_openai_client()
     # 提取患者信息
     patient_info = f"### 患者信息\n年龄：{profile['age']}\n性别：{profile['gender']}\n职业：{profile['occupation']}\n婚姻状况：{profile['martial_status']}\n症状：{profile['symptoms']}"
     # 提取对话记录


### PR DESCRIPTION
## Summary
- include server script defaults alongside model settings
- expose those values in config loader and project initialization templates
- clarify README instructions about startup scripts

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6883b0c8c4b083278606700625d18aeb