### PR TITLE
Add distinct OpenAI clients per server

### DIFF
--- a/backbone.py
+++ b/backbone.py
@@ -9,8 +9,29 @@ _cfg = AnnaEngineConfig.load()
 model_name: str = _cfg.model_name
 api_key: str = _cfg.api_key
 base_url: str = _cfg.base_url
+complaint_api_key: str = _cfg.complaint_api_key
+counselor_api_key: str = _cfg.counselor_api_key
+emotion_api_key: str = _cfg.emotion_api_key
+complaint_base_url: str = _cfg.complaint_base_url
+counselor_base_url: str = _cfg.counselor_base_url
+emotion_base_url: str = _cfg.emotion_base_url
 
 
 def get_openai_client(api_key_override: str | None = None, base_url_override: str | None = None) -> OpenAI:
     """Create an OpenAI client using configuration values."""
     return OpenAI(api_key=api_key_override or api_key, base_url=base_url_override or base_url)
+
+
+def get_complaint_client() -> OpenAI:
+    """Create a client for the complaint server."""
+    return get_openai_client(complaint_api_key, complaint_base_url)
+
+
+def get_counselor_client() -> OpenAI:
+    """Create a client for the counselor server."""
+    return get_openai_client(counselor_api_key, counselor_base_url)
+
+
+def get_emotion_client() -> OpenAI:
+    """Create a client for the emotion server."""
+    return get_openai_client(emotion_api_key, emotion_base_url)

--- a/complaint_chain.py
+++ b/complaint_chain.py
@@ -1,4 +1,4 @@
-from backbone import get_openai_client
+from backbone import get_complaint_client
 from event_trigger import event_trigger
 import json
 
@@ -36,7 +36,7 @@ model_name = "complaint"
 def gen_complaint_chain(profile):
     patient_info = f"### 患者信息\n年龄：{profile['age']}\n性别：{profile['gender']}\n职业：{profile['occupation']}\n婚姻状况：{profile['martial_status']}\n症状：{profile['symptoms']}"
     event = event_trigger(profile)
-    client = get_openai_client()
+    client = get_complaint_client()
     response = client.chat.completions.create(
         model=model_name,
         messages=[

--- a/complaint_elicitor.py
+++ b/complaint_elicitor.py
@@ -1,4 +1,4 @@
-from backbone import get_openai_client, model_name
+from backbone import get_counselor_client, model_name
 import json
 
 tools = [
@@ -28,7 +28,7 @@ def transform_chain(chain):
     return transformed_chain
 
 def switch_complaint(chain, index, conversation):
-    client = get_openai_client()
+    client = get_counselor_client()
 
     try:
         transformed_chain = transform_chain(chain)

--- a/config/defaults.py
+++ b/config/defaults.py
@@ -11,4 +11,12 @@ class AnnaEngineDefaults:
     counselor_server: str = "bash counselor.sh"
     emotion_server: str = "bash emotion.sh"
 
+    complaint_api_key: str = "complaint_chain"
+    counselor_api_key: str = "counselor"
+    emotion_api_key: str = "emotion_inferencer"
+
+    complaint_base_url: str = "http://localhost:8001/v1"
+    counselor_base_url: str = "http://localhost:8002/v1"
+    emotion_base_url: str = "http://localhost:8003/v1"
+
 anna_engine_defaults = AnnaEngineDefaults()

--- a/config/init_content.py
+++ b/config/init_content.py
@@ -24,6 +24,12 @@ ANNA_ENGINE_BASE_URL={anna_engine_defaults.base_url}
 ANNA_ENGINE_COMPLAINT_SERVER={anna_engine_defaults.complaint_server}
 ANNA_ENGINE_COUNSELOR_SERVER={anna_engine_defaults.counselor_server}
 ANNA_ENGINE_EMOTION_SERVER={anna_engine_defaults.emotion_server}
+ANNA_ENGINE_COMPLAINT_API_KEY={anna_engine_defaults.complaint_api_key}
+ANNA_ENGINE_COUNSELOR_API_KEY={anna_engine_defaults.counselor_api_key}
+ANNA_ENGINE_EMOTION_API_KEY={anna_engine_defaults.emotion_api_key}
+ANNA_ENGINE_COMPLAINT_BASE_URL={anna_engine_defaults.complaint_base_url}
+ANNA_ENGINE_COUNSELOR_BASE_URL={anna_engine_defaults.counselor_base_url}
+ANNA_ENGINE_EMOTION_BASE_URL={anna_engine_defaults.emotion_base_url}
 GLOBAL_RETRIES=3
 SCHEDULE_PARAM=default
 """

--- a/config/models/anna_engine_config.py
+++ b/config/models/anna_engine_config.py
@@ -16,6 +16,22 @@ class AnnaEngineConfig(BaseModel):
     complaint_server: str = Field(default=anna_engine_defaults.complaint_server)
     counselor_server: str = Field(default=anna_engine_defaults.counselor_server)
     emotion_server: str = Field(default=anna_engine_defaults.emotion_server)
+    complaint_api_key: str = Field(
+        default=anna_engine_defaults.complaint_api_key
+    )
+    counselor_api_key: str = Field(
+        default=anna_engine_defaults.counselor_api_key
+    )
+    emotion_api_key: str = Field(
+        default=anna_engine_defaults.emotion_api_key
+    )
+    complaint_base_url: str = Field(
+        default=anna_engine_defaults.complaint_base_url
+    )
+    counselor_base_url: str = Field(
+        default=anna_engine_defaults.counselor_base_url
+    )
+    emotion_base_url: str = Field(default=anna_engine_defaults.emotion_base_url)
 
     @classmethod
     def load(cls, root_dir: str | Path | None = None) -> "AnnaEngineConfig":
@@ -39,6 +55,24 @@ class AnnaEngineConfig(BaseModel):
             ),
             "emotion_server": pref(
                 "EMOTION_SERVER", anna_engine_defaults.emotion_server
+            ),
+            "complaint_api_key": pref(
+                "COMPLAINT_API_KEY", anna_engine_defaults.complaint_api_key
+            ),
+            "counselor_api_key": pref(
+                "COUNSELOR_API_KEY", anna_engine_defaults.counselor_api_key
+            ),
+            "emotion_api_key": pref(
+                "EMOTION_API_KEY", anna_engine_defaults.emotion_api_key
+            ),
+            "complaint_base_url": pref(
+                "COMPLAINT_BASE_URL", anna_engine_defaults.complaint_base_url
+            ),
+            "counselor_base_url": pref(
+                "COUNSELOR_BASE_URL", anna_engine_defaults.counselor_base_url
+            ),
+            "emotion_base_url": pref(
+                "EMOTION_BASE_URL", anna_engine_defaults.emotion_base_url
             ),
         }
         return cls(**values)

--- a/counselor.py
+++ b/counselor.py
@@ -1,8 +1,8 @@
-from backbone import get_openai_client, model_name
+from backbone import get_counselor_client, model_name
 
 
 def counsel(messages):
-    client = get_openai_client()
+    client = get_counselor_client()
     response = client.chat.completions.create(
         messages=messages,
         model=model_name,

--- a/emotion_modulator.py
+++ b/emotion_modulator.py
@@ -1,6 +1,6 @@
 from random import randint
 from emotion_pertuber import perturb_state
-from backbone import get_openai_client
+from backbone import get_emotion_client
 import json
 
 
@@ -58,7 +58,7 @@ model_name = "emotion"
 
 
 def emotion_inferencer(profile, conversation):
-    client = get_openai_client()
+    client = get_emotion_client()
     patient_info = f"### 患者信息\n年龄：{profile['age']}\n性别：{profile['gender']}\n职业：{profile['occupation']}\n婚姻状况：{profile['martial_status']}\n症状：{profile['symptoms']}"
     dialogue_history = "\n".join([f"{conv['role']}: {conv['content']}" for conv in conversation])
     response = client.chat.completions.create(

--- a/event_trigger.py
+++ b/event_trigger.py
@@ -1,6 +1,6 @@
 import pandas as pd
 from random import choice
-from backbone import get_openai_client, model_name
+from backbone import get_counselor_client, model_name
 import json
 
 
@@ -46,7 +46,7 @@ def event_trigger(profile):
 
 
 def situationalising_events(profile):
-    client = get_openai_client()
+    client = get_counselor_client()
     patient_info = f"### 患者信息\n年龄：{profile['age']}\n性别：{profile['gender']}"
     event = event_trigger(profile)
     response = client.chat.completions.create(

--- a/fill_scales.py
+++ b/fill_scales.py
@@ -1,5 +1,5 @@
 import json
-from backbone import get_openai_client, model_name
+from backbone import get_counselor_client, model_name
 
 tools = [
     {
@@ -75,7 +75,7 @@ def fill_scales_previous(profile, report):
     """
     结构化信息转换成非结构化文本数据，免去模型对语义解析的理解错误
     """
-    client = get_openai_client()
+    client = get_counselor_client()
 
     # Step 0：原始数据
   
@@ -266,7 +266,7 @@ def fill_scales_previous(profile, report):
 
 # 根据prompt填写量表
 def fill_scales(prompt):
-    client = get_openai_client()
+    client = get_counselor_client()
     print(prompt)
     # 填写BDI量表
     task_prompt1 = (

--- a/ms_patient.py
+++ b/ms_patient.py
@@ -1,4 +1,4 @@
-from backbone import get_openai_client, model_name
+from backbone import get_counselor_client, model_name
 from fill_scales import fill_scales, fill_scales_previous
 from event_trigger import event_trigger, situationalising_events
 from emotion_modulator import emotion_modulation
@@ -59,7 +59,7 @@ class MsPatient:
         # 选取对话样例
         self.system = prompt_template.format(**self.configuration)
         self.chain_index = 1
-        self.client = get_openai_client()
+        self.client = get_counselor_client()
 
     def chat(self, message):
         # 更新消息列表

--- a/querier.py
+++ b/querier.py
@@ -1,5 +1,5 @@
 import json
-from backbone import get_openai_client, model_name
+from backbone import get_counselor_client, model_name
 
 tools = [
     {
@@ -37,7 +37,7 @@ tools = [
 ]
 
 def is_need(utterance):
-    client = get_openai_client()
+    client = get_counselor_client()
     messages = [
         {
             "role": "user",
@@ -64,7 +64,7 @@ def is_need(utterance):
 
 def query(utterance, conversations, scales):
     # 根据utterance从conversations和scales中检索必要的信息
-    client = get_openai_client()
+    client = get_counselor_client()
     response = client.chat.completions.create(
         model=model_name,
         messages=[

--- a/short_term_memory.py
+++ b/short_term_memory.py
@@ -1,5 +1,5 @@
 import json
-from backbone import get_openai_client, model_name
+from backbone import get_counselor_client, model_name
 
 tools = [
     {
@@ -40,7 +40,7 @@ tools = [
 ]
 
 def analyzing_changes(scales):
-    client = get_openai_client()
+    client = get_counselor_client()
     # 导入量表及问题
     bdi_scale = json.load(open("./scales/bdi.json", "r"))
     ghq_scale = json.load(open("./scales/ghq-28.json", "r"))
@@ -202,7 +202,7 @@ def analyzing_changes(scales):
     return bdi_changes, ghq_changes, sass_changes
 
 def summarize_scale_changes(scales):
-    client = get_openai_client()
+    client = get_counselor_client()
     # 获取量表变化
     bdi_changes, ghq_changes, sass_changes = analyzing_changes(scales)
     messages = [

--- a/style_analyzer.py
+++ b/style_analyzer.py
@@ -1,4 +1,4 @@
-from backbone import get_openai_client, model_name
+from backbone import get_counselor_client, model_name
 import json
 
 tools = [
@@ -27,7 +27,7 @@ tools = [
 
 
 def analyze_style(profile, conversations):
-    client = get_openai_client()
+    client = get_counselor_client()
     # 提取患者信息
     patient_info = f"### 患者信息\n年龄：{profile['age']}\n性别：{profile['gender']}\n职业：{profile['occupation']}\n婚姻状况：{profile['martial_status']}\n症状：{profile['symptoms']}"
     # 提取对话记录


### PR DESCRIPTION
## Summary
- add dedicated API keys and base URLs for complaint, counselor and emotion services
- expose helper functions for each service in `backbone`
- update modules to use the proper OpenAI client per service
- extend default config and initialization templates

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6883bbfb48c08327a3d85993f0c4db2e