### PR TITLE
Add English developer guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ In addition, we will continue to train and release emotion inferencers and chief
 
 ## Synthetic Data
 We used the [CPsyCounD](https://github.com/CAS-SIAT-XinHai/CPsyCoun) dataset as a seed to synthesize a seeker bank that meets the requirements of the AnnaAgent format using GPT-4o-mini. It can be found at this [link](https://huggingface.co/datasets/sci-m-wang/Anna-CPsyCounD). We will continue to transform more data and will create more realistic seeker characters based on AnnaAgent for use in related research.
+## Developer Guide
+
+For contribution guidelines refer to:
+- [开发者指南 (Chinese)](src/docs/contributing/code.md)
+- [Developer Guide (English)](src/docs/contributing/code_en.md)
+
 
 ## Citation
 ```bibtex

--- a/src/docs/contributing/code.md
+++ b/src/docs/contributing/code.md
@@ -1,0 +1,77 @@
+# 开发者指南
+
+本文档说明如何在本仓库进行开发和贡献代码。本仓库使用 [Poetry](https://python-poetry.org/) 管理依赖，并通过 `Makefile` 提供常用的格式化、代码检查和测试命令。
+
+## 代码贡献流程
+
+- 除项目维护者外，请遵循 [fork and pull request](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-a-project) 流程进行贡献。
+- 提交 PR 前请按照 Pull Request 模板填写相关内容。
+- CI 会自动运行 lint 和测试，请在本地确保通过所有检查。
+- 如果新增功能或修复 Bug，请同步更新相关文档，并尽可能在 `tests/unit_tests` 或 `tests/integration_tests` 中添加测试。
+
+## 依赖安装
+
+本项目依赖使用 Poetry 管理。在安装 Poetry 之前，如使用 Conda，建议先创建并激活新的环境，例如：
+
+```bash
+conda create -n annaagent python=3.10
+conda activate annaagent
+```
+
+安装 Poetry 可参考其 [官方文档](https://python-poetry.org/docs/#installing-with-pipx)。安装完成后，如使用 Conda 或 Pyenv 管理 Python，请执行：
+
+```bash
+poetry config virtualenvs.prefer-active-python true
+```
+
+在仓库根目录执行以下命令安装开发所需依赖（包含 lint 与测试工具）：
+
+```bash
+poetry install --with lint,test
+```
+
+## 常用开发命令
+
+本仓库提供 `Makefile` 方便执行常用任务。以下命令均在仓库根目录运行。
+
+### 代码格式化
+
+使用 [ruff](https://docs.astral.sh/ruff/) 进行格式化：
+
+```bash
+make format
+```
+
+### 代码检查
+
+运行静态检查和导入检查：
+
+```bash
+make lint
+```
+
+### 单元测试
+
+运行单元测试：
+
+```bash
+make test
+```
+
+### 集成测试
+
+运行集成测试：
+
+```bash
+make integration_tests
+```
+
+### 覆盖率报告
+
+生成覆盖率报告：
+
+```bash
+make coverage
+```
+
+更多命令可执行 `make help` 查看。

--- a/src/docs/contributing/code_en.md
+++ b/src/docs/contributing/code_en.md
@@ -1,0 +1,77 @@
+# Developer Guide
+
+This document describes how to develop and contribute code to this repository. The project uses [Poetry](https://python-poetry.org/) to manage dependencies and provides a `Makefile` with common formatting, linting and testing commands.
+
+## Contribution Workflow
+
+- Except for maintainers, please follow the [fork and pull request](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-a-project) workflow.
+- Fill in the Pull Request template before submitting.
+- Continuous integration will run lint and tests automatically. Make sure all checks pass locally.
+- When adding features or fixing bugs, update the documentation accordingly and add tests in `tests/unit_tests` or `tests/integration_tests` whenever possible.
+
+## Dependency Installation
+
+The project dependencies are managed with Poetry. If you are using Conda, it is recommended to create and activate a new environment first:
+
+```bash
+conda create -n annaagent python=3.10
+conda activate annaagent
+```
+
+Install Poetry following its [official guide](https://python-poetry.org/docs/#installing-with-pipx). After installation, if you use Conda or Pyenv, run:
+
+```bash
+poetry config virtualenvs.prefer-active-python true
+```
+
+Then install all development dependencies (including lint and test tools) from the repository root:
+
+```bash
+poetry install --with lint,test
+```
+
+## Common Development Commands
+
+The repository provides a `Makefile` to easily run common tasks. All commands are executed from the project root.
+
+### Code Formatting
+
+Use [ruff](https://docs.astral.sh/ruff/) to format the code:
+
+```bash
+make format
+```
+
+### Linting
+
+Run static and import checks:
+
+```bash
+make lint
+```
+
+### Unit Tests
+
+Run the unit tests:
+
+```bash
+make test
+```
+
+### Integration Tests
+
+Run the integration tests:
+
+```bash
+make integration_tests
+```
+
+### Coverage Report
+
+Generate a coverage report:
+
+```bash
+make coverage
+```
+
+Run `make help` for more commands.


### PR DESCRIPTION
## Summary
- add English version of developer guide
- link both guides from the README

## Testing
- `poetry install --with lint,test` *(fails: could not connect to pypi.tuna.tsinghua.edu.cn)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'environs')*

------
https://chatgpt.com/codex/tasks/task_e_68849822736c83279e828cff0b3195e2