### PR TITLE
Update workspace option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,34 @@ python -m anna_agent.initialize
 anna-agent
 ```
 
-The command accepts an optional `--config` argument to load a custom
-`interactive.yaml`:
+After initialization you can chat with the virtual seeker.
+
+## CLI Usage
+
+AnnaAgent provides a small Typer-based command line interface with two entry
+points. After initializing the project you can either run the built-in demo or
+start a conversation using your own `interactive.yaml`.
+
+### Demo
+
+Launch the demo seeker defined in the source code:
 
 ```bash
-anna-agent --config path/to/my_interactive.yaml
+anna-agent demo
 ```
 
-Then, you can chat with the virtual seeker.
+Both `demo` and the main command accept `--workspace` (also available as
+`--root`) to specify the project directory. Each workspace directory should
+contain both a `settings.yaml` and an `interactive.yaml` file.
+
+### Interactive mode
+
+Running `anna-agent` without a subcommand uses the `interactive.yaml` in the
+project directory and starts chatting with the virtual seeker:
+
+```bash
+anna-agent
+```
 
 ## Project Initialization
 

--- a/src/anna_agent/cli.py
+++ b/src/anna_agent/cli.py
@@ -12,10 +12,8 @@ _interactive_config_files = ["interactive.yaml", "interactive.yml", "interactive
 app = typer.Typer(help="AnnaAgent CLI", invoke_without_command=True)
 
 
-def _get_config_path(root: Path, config: Path | None) -> Path:
+def _get_config_path(root: Path) -> Path:
     """Return the path to the interactive config file."""
-    if config:
-        return config
     for name in _interactive_config_files:
         candidate = root / name
         if candidate.is_file():
@@ -133,20 +131,16 @@ def _interactive_demo() -> None:
 
 @app.command()
 def demo(
-    config: Path | None = typer.Option(
-        None,
-        "--config",
-        "-c",
-        help="Configuration file to use.",
-        exists=True,
-        file_okay=True,
-        readable=True,
-    ),
-    root: Path = typer.Option(
+    workspace: Path = typer.Option(
         Path(),
+        "--workspace",
         "--root",
+        "-w",
         "-r",
-        help="Project root directory.",
+        help=(
+            "Directory containing settings.yaml and interactive.yaml. "
+            "Defaults to the current working directory."
+        ),
         exists=True,
         dir_okay=True,
         writable=True,
@@ -154,27 +148,23 @@ def demo(
     ),
 ) -> None:
     """Run the interactive demo."""
-    load_config(root, config, None)
+    load_config(workspace)
     _interactive_demo()
 
 
 @app.callback()
 def main(
     ctx: typer.Context,
-    config: Path | None = typer.Option(
-        None,
-        "--config",
-        "-c",
-        help="Configuration file to use.",
-        exists=True,
-        file_okay=True,
-        readable=True,
-    ),
-    root: Path = typer.Option(
+    workspace: Path = typer.Option(
         Path(),
+        "--workspace",
         "--root",
+        "-w",
         "-r",
-        help="Project root directory.",
+        help=(
+            "Directory containing settings.yaml and interactive.yaml. "
+            "Defaults to the current working directory."
+        ),
         exists=True,
         dir_okay=True,
         writable=True,
@@ -186,8 +176,8 @@ def main(
 
     if ctx.invoked_subcommand is not None:
         return
-    load_config(root, None, None)
-    cfg_path = _get_config_path(root, config)
+    load_config(workspace)
+    cfg_path = _get_config_path(workspace)
     portrait, report, conv = _load_seeker_data(cfg_path)
     seeker = MsPatient(portrait, report, conv)
     _interactive_chat(seeker)

--- a/src/anna_agent/config/load_config.py
+++ b/src/anna_agent/config/load_config.py
@@ -33,15 +33,12 @@ def _load_dotenv(config_path: Path | str) -> None:
         load_dotenv(dotenv_path)
 
 
-def _get_config_path(root_dir: Path, config_filepath: Path | None) -> Path:
-    if config_filepath:
-        config_path = config_filepath.resolve()
-        if not config_path.exists():
-            raise FileNotFoundError(f"Specified Config file not found: {config_path}")
-    else:
-        config_path = _search_for_config_in_root_dir(root_dir)
+def _get_config_path(root_dir: Path) -> Path:
+    config_path = _search_for_config_in_root_dir(root_dir)
     if not config_path:
-        raise FileNotFoundError(f"Config file not found in root directory: {root_dir}")
+        raise FileNotFoundError(
+            f"Config file not found in root directory: {root_dir}"
+        )
     return config_path
 
 
@@ -96,11 +93,10 @@ def _flatten_config(data: dict[str, Any]) -> dict[str, Any]:
 
 def load_config(
     root_dir: Path,
-    config_filepath: Path | None = None,
     cli_overrides: dict[str, Any] | None = None,
 ) -> AnnaEngineConfig:
     root = root_dir.resolve()
-    config_path = _get_config_path(root, config_filepath)
+    config_path = _get_config_path(root)
     _load_dotenv(config_path)
     config_extension = config_path.suffix
     config_text = config_path.read_text(encoding="utf-8")

--- a/tests/unit_tests/test_cli_utils.py
+++ b/tests/unit_tests/test_cli_utils.py
@@ -59,6 +59,9 @@ def test_load_seeker_data_missing(tmp_path: Path) -> None:
 def test_get_config_path_default(tmp_path: Path) -> None:
     """_get_config_path should prefer interactive.yaml if present."""
     interactive = tmp_path / "interactive.yaml"
-    interactive.write_text("portrait: {}\nreport: {}\nprevious_conversations: []", encoding="utf-8")
-    path = _get_config_path(tmp_path, None)
+    interactive.write_text(
+        "portrait: {}\nreport: {}\nprevious_conversations: []",
+        encoding="utf-8",
+    )
+    path = _get_config_path(tmp_path)
     assert path == interactive


### PR DESCRIPTION
## Summary
- rename `--root` CLI option to `--workspace` (keep `--root` as alias)
- document workspace requirement in README
- remove optional config path from `load_config`
- update demo and main commands to use simplified `load_config`
- drop `--config` option so workspace alone selects `interactive.yaml`

## Testing
- `make test`
- `make lint` *(fails: style errors in repo)*

------
https://chatgpt.com/codex/tasks/task_e_6884d1e8ce548327b46ad430e8e9d317