### PR TITLE
Load model names from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,11 @@ python -m anna_agent.initialize
 ```
 
 The generated `settings.yaml` contains the model service settings and per-module
-server configuration including API keys and base URLs for the complaint,
-counselor and emotion modules. `interactive.yaml` holds a sample portrait,
-report and conversation history used by the main CLI. Environment variables are
-written to `.env` with the `ANNA_ENGINE_` prefix for easy override.
+server configuration including API keys, base URLs and model names for the
+complaint, counselor and emotion modules. `interactive.yaml` holds a sample
+portrait, report and conversation history used by the main CLI. Environment
+variables are written to `.env` with the `ANNA_ENGINE_` prefix for easy
+override.
 
 ## Work Progress
 

--- a/src/anna_agent/backbone.py
+++ b/src/anna_agent/backbone.py
@@ -15,6 +15,8 @@ emotion_api_key: str = _cfg.emotion_api_key
 complaint_base_url: str = _cfg.complaint_base_url
 counselor_base_url: str = _cfg.counselor_base_url
 emotion_base_url: str = _cfg.emotion_base_url
+complaint_model_name: str = _cfg.complaint_model_name
+emotion_model_name: str = _cfg.emotion_model_name
 
 
 def get_openai_client(

--- a/src/anna_agent/complaint_chain.py
+++ b/src/anna_agent/complaint_chain.py
@@ -1,4 +1,4 @@
-from .backbone import get_complaint_client
+from .backbone import get_complaint_client, complaint_model_name
 from .event_trigger import event_trigger
 import json
 
@@ -33,7 +33,6 @@ tools = [
     }
 ]
 
-model_name = "complaint"
 
 
 def gen_complaint_chain(profile):
@@ -41,7 +40,7 @@ def gen_complaint_chain(profile):
     event = event_trigger(profile)
     client = get_complaint_client()
     response = client.chat.completions.create(
-        model=model_name,
+        model=complaint_model_name,
         messages=[
             {
                 "role": "user",

--- a/src/anna_agent/config/defaults.py
+++ b/src/anna_agent/config/defaults.py
@@ -13,6 +13,9 @@ class AnnaEngineDefaults:
     counselor_api_key: str = "counselor"
     emotion_api_key: str = "emotion_inferencer"
 
+    complaint_model_name: str = "complaint"
+    emotion_model_name: str = "emotion"
+
     complaint_base_url: str = "http://localhost:8001/v1"
     counselor_base_url: str = "http://localhost:8002/v1"
     emotion_base_url: str = "http://localhost:8000/v1"

--- a/src/anna_agent/config/init_content.py
+++ b/src/anna_agent/config/init_content.py
@@ -9,12 +9,14 @@ model_service:
   base_url: {anna_engine_defaults.base_url}
 servers:
   complaint:
+    model_name: {anna_engine_defaults.complaint_model_name}
     api_key: {anna_engine_defaults.complaint_api_key}
     base_url: {anna_engine_defaults.complaint_base_url}
   counselor:
     api_key: {anna_engine_defaults.counselor_api_key}
     base_url: {anna_engine_defaults.counselor_base_url}
   emotion:
+    model_name: {anna_engine_defaults.emotion_model_name}
     api_key: {anna_engine_defaults.emotion_api_key}
     base_url: {anna_engine_defaults.emotion_base_url}
 """

--- a/src/anna_agent/config/load_config.py
+++ b/src/anna_agent/config/load_config.py
@@ -80,6 +80,7 @@ def _flatten_config(data: dict[str, Any]) -> dict[str, Any]:
     complaint = servers.get("complaint") or {}
     values["complaint_api_key"] = complaint.get("api_key")
     values["complaint_base_url"] = complaint.get("base_url")
+    values["complaint_model_name"] = complaint.get("model_name")
 
     counselor = servers.get("counselor") or {}
     values["counselor_api_key"] = counselor.get("api_key")
@@ -88,6 +89,7 @@ def _flatten_config(data: dict[str, Any]) -> dict[str, Any]:
     emotion = servers.get("emotion") or {}
     values["emotion_api_key"] = emotion.get("api_key")
     values["emotion_base_url"] = emotion.get("base_url")
+    values["emotion_model_name"] = emotion.get("model_name")
     return values
 
 

--- a/src/anna_agent/config/models/anna_engine_config.py
+++ b/src/anna_agent/config/models/anna_engine_config.py
@@ -16,6 +16,12 @@ class AnnaEngineConfig(BaseModel):
     complaint_api_key: str = Field(default=anna_engine_defaults.complaint_api_key)
     counselor_api_key: str = Field(default=anna_engine_defaults.counselor_api_key)
     emotion_api_key: str = Field(default=anna_engine_defaults.emotion_api_key)
+    complaint_model_name: str = Field(
+        default=anna_engine_defaults.complaint_model_name
+    )
+    emotion_model_name: str = Field(
+        default=anna_engine_defaults.emotion_model_name
+    )
     complaint_base_url: str = Field(default=anna_engine_defaults.complaint_base_url)
     counselor_base_url: str = Field(default=anna_engine_defaults.counselor_base_url)
     emotion_base_url: str = Field(default=anna_engine_defaults.emotion_base_url)
@@ -64,6 +70,14 @@ class AnnaEngineConfig(BaseModel):
                 "emotion_base_url": reader.str(
                     "EMOTION_BASE_URL",
                     default_value=anna_engine_defaults.emotion_base_url,
+                ),
+                "complaint_model_name": reader.str(
+                    "COMPLAINT_MODEL_NAME",
+                    default_value=anna_engine_defaults.complaint_model_name,
+                ),
+                "emotion_model_name": reader.str(
+                    "EMOTION_MODEL_NAME",
+                    default_value=anna_engine_defaults.emotion_model_name,
                 ),
             }
         return cls(**values)

--- a/src/anna_agent/emotion_modulator.py
+++ b/src/anna_agent/emotion_modulator.py
@@ -1,6 +1,6 @@
 from random import randint
 from .emotion_pertuber import perturb_state
-from .backbone import get_emotion_client
+from .backbone import get_emotion_client, emotion_model_name
 import json
 
 
@@ -54,7 +54,6 @@ tools = [
     }
 ]
 
-model_name = "emotion"
 
 
 def emotion_inferencer(profile, conversation):
@@ -64,7 +63,7 @@ def emotion_inferencer(profile, conversation):
         [f"{conv['role']}: {conv['content']}" for conv in conversation]
     )
     response = client.chat.completions.create(
-        model=model_name,
+        model=emotion_model_name,
         messages=[
             {
                 "role": "user",

--- a/tests/integration_tests/test_load_config.py
+++ b/tests/integration_tests/test_load_config.py
@@ -15,12 +15,14 @@ model_service:
   base_url: https://example.com
 servers:
   complaint:
+    model_name: cm
     api_key: ckey
     base_url: https://c.example.com
   counselor:
     api_key: cokey
     base_url: https://co.example.com
   emotion:
+    model_name: em
     api_key: ekey
     base_url: https://e.example.com
 """,
@@ -30,3 +32,5 @@ servers:
     assert config.model_name == "test-model"
     assert config.complaint_base_url == "https://c.example.com"
     assert config.counselor_api_key == "cokey"
+    assert config.complaint_model_name == "cm"
+    assert config.emotion_model_name == "em"

--- a/tests/unit_tests/test_load_config_utils.py
+++ b/tests/unit_tests/test_load_config_utils.py
@@ -23,9 +23,17 @@ def test_flatten_config():
             "base_url": "u",
         },
         "servers": {
-            "complaint": {"api_key": "c", "base_url": "cu"},
+            "complaint": {
+                "api_key": "c",
+                "base_url": "cu",
+                "model_name": "cm",
+            },
             "counselor": {"api_key": "co", "base_url": "cou"},
-            "emotion": {"api_key": "e", "base_url": "eu"},
+            "emotion": {
+                "api_key": "e",
+                "base_url": "eu",
+                "model_name": "em",
+            },
         },
     }
     result = _flatten_config(src)
@@ -39,4 +47,6 @@ def test_flatten_config():
         "counselor_base_url": "cou",
         "emotion_api_key": "e",
         "emotion_base_url": "eu",
+        "complaint_model_name": "cm",
+        "emotion_model_name": "em",
     }


### PR DESCRIPTION
## Summary
- add fields for complaint and emotion model names
- expose them through AnnaEngineConfig and backbone
- update default settings and example config
- use the new values in complaint_chain and emotion_modulator
- document new configuration entries in README
- adjust tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6888c443d9208327bffca3111ce3cfd7