### PR TITLE
Fix dynamic config loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,13 @@ portrait, report and conversation history used by the main CLI. Environment
 variables are written to `.env` with the `ANNA_ENGINE_` prefix for easy
 override.
 
+The `anna_agent` package loads its configuration from the workspace directory at
+runtime using `settings.yaml`. By default the current working directory is used,
+but you can override the location by setting the `ANNA_AGENT_WORKSPACE`
+environment variable.  When using the library programmatically you can also
+call `anna_agent.backbone.configure(<workspace>)` to load the desired
+configuration on demand.
+
 ## Work Progress
 
 To make it easier for readers to learn how to use it, we have added the flowchart below:

--- a/src/anna_agent/cli.py
+++ b/src/anna_agent/cli.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import typer
 import yaml
 
-from .config.load_config import load_config
+from . import backbone
 
 # Possible names for the interactive configuration file
 _interactive_config_files = ["interactive.yaml", "interactive.yml", "interactive.json"]
@@ -148,7 +148,7 @@ def demo(
     ),
 ) -> None:
     """Run the interactive demo."""
-    load_config(workspace)
+    backbone.configure(workspace)
     _interactive_demo()
 
 
@@ -176,7 +176,7 @@ def main(
 
     if ctx.invoked_subcommand is not None:
         return
-    load_config(workspace)
+    backbone.configure(workspace)
     cfg_path = _get_config_path(workspace)
     portrait, report, conv = _load_seeker_data(cfg_path)
     seeker = MsPatient(portrait, report, conv)

--- a/tests/unit_tests/test_backbone_config.py
+++ b/tests/unit_tests/test_backbone_config.py
@@ -1,0 +1,37 @@
+import importlib
+from pathlib import Path
+
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+
+def test_backbone_loads_workspace(tmp_path):
+    cfg = tmp_path / "settings.yaml"
+    cfg.write_text(
+        """
+model_service:
+  model_name: my-model
+  api_key: key
+  base_url: https://example.com
+servers:
+  complaint:
+    api_key: ck
+    base_url: https://c.example.com
+    model_name: cm
+  counselor:
+    api_key: cok
+    base_url: https://co.example.com
+  emotion:
+    api_key: ek
+    base_url: https://e.example.com
+    model_name: em
+""",
+        encoding="utf-8",
+    )
+    mod = importlib.import_module("anna_agent.backbone")
+    mod.configure(tmp_path)
+    assert mod.base_url == "https://example.com"
+    assert mod.complaint_base_url == "https://c.example.com"
+    assert mod.counselor_api_key == "cok"
+    assert mod.emotion_api_key == "ek"


### PR DESCRIPTION
## Summary
- load configuration via `backbone.configure` so workspace can be chosen at runtime
- CLI passes its `--workspace` option to `configure`
- document runtime configuration override
- adjust tests for new API

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6888db2f14688327aeda8818e21c216e